### PR TITLE
Hotfixes for SR2021

### DIFF
--- a/bin/herdsman
+++ b/bin/herdsman
@@ -205,6 +205,10 @@ if __name__ == "__main__":
                         action="store_true",
                         help="Default to competition mode")
 
+    parser.add_argument("--python",
+                        type=str, default=sys.executable,
+                        help="Path to the Python interpreter to use for user code")
+
     args = parser.parse_args()
 
     if args.static_dir is None:
@@ -214,7 +218,7 @@ if __name__ == "__main__":
     if args.debug:
         log.startLogging(sys.stdout)
 
-    user = usercode.UserCodeManager(args.log_dir)
+    user = usercode.UserCodeManager(args.log_dir, args.python)
 
     if args.comp:
         user.mode = usercode.MODE_COMP

--- a/herdsman/loggrok.py
+++ b/herdsman/loggrok.py
@@ -43,4 +43,5 @@ if __name__ == "__main__":
     # Remove ourselves from the args
     sys.argv = sys.argv[1:]
 
-    execfile(prog, { "__file__": prog })
+    with open(prog) as f:
+        exec(f.read(), {"__file__": prog})

--- a/herdsman/loggrok.py
+++ b/herdsman/loggrok.py
@@ -6,6 +6,7 @@ This can be run like so:
 The result is that something.py is run after importing this module, and hence
 with the desired stdout and stderr modifications.
 """
+import os
 import sys
 
 class AddCRFlusher(object):
@@ -42,6 +43,11 @@ if __name__ == "__main__":
     prog = sys.argv[1]
     # Remove ourselves from the args
     sys.argv = sys.argv[1:]
+    # Make it look like the target file was executed as a script, even
+    # if we weren't (I'm not *entirely* sure why this is necessary, but
+    # it seems like Python only prepends $CWD to sys.path if the script
+    # was executed via `python -m xyz`, not when run as `python xyz.py`)
+    sys.path.insert(0, os.path.dirname(prog))
 
     with open(prog) as f:
         exec(f.read(), {"__file__": prog})

--- a/herdsman/usercode.py
+++ b/herdsman/usercode.py
@@ -47,8 +47,9 @@ class UserCodeManager(object):
         S_KILLING: "killing"
     }
 
-    def __init__(self, logdir):
+    def __init__(self, logdir, python_interpreter):
         self.logdir = logdir
+        self.python_interpreter = os.path.abspath(python_interpreter)
         self.zone = 0
         self.mode = MODE_DEV
         self.state = UserCodeManager.S_IDLE
@@ -110,8 +111,8 @@ class UserCodeManager(object):
                                           self._log_line_cb)
 
         self.usertransport = reactor.spawnProcess(self.userproto,
-                                                  sys.executable,
-                                                  args = [ sys.executable,
+                                                  self.python_interpreter,
+                                                  args = [ self.python_interpreter,
                                                            "-m", "herdsman.loggrok",
                                                            "robot.py",
                                                            "--usbkey", self.logdir,

--- a/herdsman/usercode.py
+++ b/herdsman/usercode.py
@@ -110,10 +110,11 @@ class UserCodeManager(object):
                                           self.logfile,
                                           self._log_line_cb)
 
+        loggrok_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "loggrok.py")
         self.usertransport = reactor.spawnProcess(self.userproto,
                                                   self.python_interpreter,
                                                   args = [ self.python_interpreter,
-                                                           "-m", "herdsman.loggrok",
+                                                           loggrok_path,
                                                            "robot.py",
                                                            "--usbkey", self.logdir,
                                                            "--startfifo", self.start_fifo ],


### PR DESCRIPTION
NB: though this is a PR, I'm not sure it makes sense to merge this into the custom-pages branch, so I'm marking it as a draft for now.

I've based this work off commit ab8f28e07, which I used to believe was the latest commit that actually made it onto the kits, though looking at some of the later commits I'm now not so sure about that.

---

This patch series makes it possible for herdsman to manage user code running in an arbitrary Python interpreter. In other words, the interpreter used to run user code can now be different (read: newer) than the interpreter used to run herdsman.

This adds a bit of complexity; we need to be very careful to avoid breaking the ability for the `robot.py` file to import modules that are in the same directory as it. Since we're no longer using `python -m` to execute loggrok, it seems like Python now doesn't add "the current directory" (presumably it actually looks at the contents of `__file__` at import time or something) to `sys.path`, so we need to do that ourselves.

It seems like it would be a better idea to use [the `runpy` module](https://docs.python.org/2.7/library/runpy.html) to do this, but from the documentation it looks like `runpy.run_path` has the same issue of not prepending `""` to `sys.path`, and `runpy.run_module` isn't usable for the same reason we can't just keep doing `-m herdsman.loggrok` – because we have no way of knowing how the interpreter we're spawning is going to do module lookup.