### PR TITLE
Allow specifying the Python interpreter to spawn

### DIFF
--- a/bin/herdsman
+++ b/bin/herdsman
@@ -213,6 +213,10 @@ if __name__ == "__main__":
                         action="store_true",
                         help="Default to competition mode")
 
+    parser.add_argument("--python",
+                        type=str, default=sys.executable,
+                        help="Path to the Python interpreter to use for user code")
+
     args = parser.parse_args()
 
     if args.static_dir is None:
@@ -222,7 +226,7 @@ if __name__ == "__main__":
     if args.debug:
         log.startLogging(sys.stdout)
 
-    user = usercode.UserCodeManager(args.log_dir)
+    user = usercode.UserCodeManager(args.log_dir, args.python)
 
     mode_settings = load_mode_settings()
 

--- a/herdsman/usercode.py
+++ b/herdsman/usercode.py
@@ -68,8 +68,9 @@ class UserCodeManager(object):
         S_KILLING: "killing"
     }
 
-    def __init__(self, logdir):
+    def __init__(self, logdir, python_interpreter):
         self.logdir = logdir
+        self.python_interpreter = os.path.abspath(python_interpreter)
         self.zone = 0
         self.mode = MODE_DEV
         self.arena = "A"
@@ -148,8 +149,8 @@ class UserCodeManager(object):
                                           self._log_line_cb)
 
         self.usertransport = reactor.spawnProcess(self.userproto,
-                                                  sys.executable,
-                                                  args = [ sys.executable,
+                                                  self.python_interpreter,
+                                                  args = [ self.python_interpreter,
                                                            "robot.py",
                                                            "--usbkey", self.logdir,
                                                            "--startfifo", self.start_fifo ],


### PR DESCRIPTION
Herdsman now accepts a `--python /path/to/python` command-line argument. If not provided, it defaults to `sys.executable`, like it used to.

Since loggrok was removed in e262fd431 (Fix #2648: Ensure that all log output is sent, 2014-10-28), this is relatively easy to implement.